### PR TITLE
Add `--pr` to open a python/peps PR preview

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10", "3.11-dev"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
         include:
           # Include new variables for Codecov
-          - { codecov-flag: GHA_Ubuntu, os: ubuntu-latest }
           - { codecov-flag: GHA_macOS, os: macos-latest }
+          - { codecov-flag: GHA_Ubuntu, os: ubuntu-latest }
           - { codecov-flag: GHA_Windows, os: windows-latest }
 
     steps:
@@ -39,8 +39,21 @@ jobs:
         run: |
           tox -e py
 
+      - name: Cog
+        if: matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
+        run: |
+          tox -e cog
+
       - name: Upload coverage
         uses: codecov/codecov-action@v2.1.0
         with:
           flags: ${{ matrix.codecov-flag }}
           name: ${{ matrix.os }} Python ${{ matrix.python-version }}
+
+  success:
+    needs: test
+    runs-on: ubuntu-latest
+    name: test successful
+    steps:
+      - name: Success
+        run: echo Test successful

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ run("pep --help")
 
 ```console
 $ pep --help
-usage: pep [-h] [-u URL] [-V] search
+usage: pep [-h] [-u URL] [--pr PR] [-V] search
 
 CLI to open PEPs in your browser
 
@@ -47,6 +47,7 @@ positional arguments:
 options:
   -h, --help         show this help message and exit
   -u URL, --url URL  Base URL for PEPs (default: https://peps.python.org)
+  --pr PR            Open preview for python/peps PR (default: None)
   -V, --version      show program's version number and exit
 ```
 
@@ -64,4 +65,11 @@ https://peps.python.org/pep-0008/
 ```console
 $ pep 3.11
 https://peps.python.org/pep-0664/
+```
+
+### Open a build preview of a python/peps PR
+
+```console
+$ pep 594 --pr 2440
+https://pep-previews--2440.org.readthedocs.build/pep-0594/
 ```

--- a/src/pepotron/__init__.py
+++ b/src/pepotron/__init__.py
@@ -2,6 +2,8 @@
 """
 CLI to open PEPs in your browser
 """
+from __future__ import annotations
+
 import webbrowser
 
 try:
@@ -38,18 +40,21 @@ VERSION_TO_PEP = {
 }
 
 
-def url(search: str, base_url: str) -> str:
+def url(search: str, base_url: str | None = None, pr: int | None = None) -> str:
     """Get PEP URL"""
     try:
         number = int(search)
     except ValueError:
         number = VERSION_TO_PEP[search]
 
+    if pr:
+        base_url = f"https://pep-previews--{pr}.org.readthedocs.build"
+
     return base_url.rstrip("/") + f"/pep-{number:04}" + "/"
 
 
-def pep(search: str, base_url: str) -> None:
+def pep(search: str, base_url: str | None = None, pr: int | None = None) -> None:
     """Open this PEP in the browser"""
-    pep_url = url(search, base_url)
+    pep_url = url(search, base_url, pr)
     print(pep_url)
     webbrowser.open(pep_url, new=2)  # 2 = open in a new tab, if possible

--- a/src/pepotron/cli.py
+++ b/src/pepotron/cli.py
@@ -18,16 +18,14 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=Formatter)
     parser.add_argument("search", help="PEP number, or Python version for its schedule")
     parser.add_argument(
-        "-u",
-        "--url",
-        default="https://peps.python.org",
-        help="Base URL for PEPs",
+        "-u", "--url", default="https://peps.python.org", help="Base URL for PEPs"
     )
+    parser.add_argument("--pr", type=int, help="Open preview for python/peps PR")
     parser.add_argument(
         "-V", "--version", action="version", version=f"%(prog)s {pepotron.__version__}"
     )
     args = parser.parse_args()
-    pepotron.pep(search=args.search, base_url=args.url)
+    pepotron.pep(search=args.search, base_url=args.url, pr=args.pr)
 
 
 if __name__ == "__main__":

--- a/tests/test_pep.py
+++ b/tests/test_pep.py
@@ -36,3 +36,13 @@ def test_url(search: str, base_url: str, expected_url: str) -> None:
     pep_url = pepotron.url(search, base_url)
     # Assert
     assert pep_url == expected_url
+
+
+def test_url_pr() -> None:
+    # Arrange
+    search = "594"
+    pr = 2440
+    # Act
+    pep_url = pepotron.url(search, pr=pr)
+    # Assert
+    assert pep_url == "https://pep-previews--2440.org.readthedocs.build/pep-0594/"

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ commands =
     pep --help
 
 [testenv:cog]
-skip_install = true
 deps =
     cogapp
 commands =


### PR DESCRIPTION
Add `--pr` to open the ReadTheDocs build preview of PRs at https://github.com/python/peps.

For example, for PR https://github.com/python/peps/pull/2440:

```console
$ pep 594 --pr 2440
https://pep-previews--2440.org.readthedocs.build/pep-0594/
```
