### PR TITLE
Make 'search' optional to open homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ usage: pep [-h] [-u URL] [-p PR] [-V] [search]
 CLI to open PEPs in your browser
 
 positional arguments:
-  search             PEP number, or Python version for its schedule
+  search             PEP number, or Python version for its schedule (default:
+                     None)
 
 options:
   -h, --help         show this help message and exit

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ run("pep --help")
 
 ```console
 $ pep --help
-usage: pep [-h] [-u URL] [--pr PR] [-V] search
+usage: pep [-h] [-u URL] [-p PR] [-V] [search]
 
 CLI to open PEPs in your browser
 
@@ -47,7 +47,7 @@ positional arguments:
 options:
   -h, --help         show this help message and exit
   -u URL, --url URL  Base URL for PEPs (default: https://peps.python.org)
-  --pr PR            Open preview for python/peps PR (default: None)
+  -p PR, --pr PR     Open preview for python/peps PR (default: None)
   -V, --version      show program's version number and exit
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,3 +74,12 @@ https://peps.python.org/pep-0664/
 $ pep 594 --pr 2440
 https://pep-previews--2440.org.readthedocs.build/pep-0594/
 ```
+
+### Open the PEPs website
+
+```console
+$ pep
+https://peps.python.org/
+$ pep --pr 2440
+https://pep-previews--2440.org.readthedocs.build
+```

--- a/src/pepotron/__init__.py
+++ b/src/pepotron/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 CLI to open PEPs in your browser
 """
@@ -40,17 +39,22 @@ VERSION_TO_PEP = {
 }
 
 
-def url(search: str, base_url: str | None = None, pr: int | None = None) -> str:
+def url(search: str | None, base_url: str | None = None, pr: int | None = None) -> str:
     """Get PEP URL"""
-    try:
-        number = int(search)
-    except ValueError:
-        number = VERSION_TO_PEP[search]
-
     if pr:
         base_url = f"https://pep-previews--{pr}.org.readthedocs.build"
 
-    return base_url.rstrip("/") + f"/pep-{number:04}" + "/"
+    result = base_url.rstrip("/")
+
+    if search:
+        try:
+            number = int(search)
+        except ValueError:
+            number = VERSION_TO_PEP[search]
+
+        result += f"/pep-{number:04}/"
+
+    return result
 
 
 def pep(search: str, base_url: str | None = None, pr: int | None = None) -> None:

--- a/src/pepotron/cli.py
+++ b/src/pepotron/cli.py
@@ -20,7 +20,7 @@ def main() -> None:
     parser.add_argument(
         "-u", "--url", default="https://peps.python.org", help="Base URL for PEPs"
     )
-    parser.add_argument("--pr", type=int, help="Open preview for python/peps PR")
+    parser.add_argument("-p", "--pr", type=int, help="Open preview for python/peps PR")
     parser.add_argument(
         "-V", "--version", action="version", version=f"%(prog)s {pepotron.__version__}"
     )

--- a/src/pepotron/cli.py
+++ b/src/pepotron/cli.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 CLI to open PEPs in your browser
 """
@@ -16,7 +15,9 @@ class Formatter(
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=Formatter)
-    parser.add_argument("search", help="PEP number, or Python version for its schedule")
+    parser.add_argument(
+        "search", nargs="?", help="PEP number, or Python version for its schedule"
+    )
     parser.add_argument(
         "-u", "--url", default="https://peps.python.org", help="Base URL for PEPs"
     )

--- a/tests/test_pep.py
+++ b/tests/test_pep.py
@@ -29,6 +29,11 @@ import pepotron
             "https://hugovk.github.io/peps",
             "https://hugovk.github.io/peps/pep-0664/",
         ),
+        (
+            None,
+            "https://peps.python.org",
+            "https://peps.python.org",
+        ),
     ],
 )
 def test_url(search: str, base_url: str, expected_url: str) -> None:
@@ -38,11 +43,17 @@ def test_url(search: str, base_url: str, expected_url: str) -> None:
     assert pep_url == expected_url
 
 
-def test_url_pr() -> None:
+@pytest.mark.parametrize(
+    "search, expected_url",
+    [
+        ("594", "https://pep-previews--2440.org.readthedocs.build/pep-0594/"),
+        (None, "https://pep-previews--2440.org.readthedocs.build"),
+    ],
+)
+def test_url_pr(search, expected_url) -> None:
     # Arrange
-    search = "594"
     pr = 2440
     # Act
     pep_url = pepotron.url(search, pr=pr)
     # Assert
-    assert pep_url == "https://pep-previews--2440.org.readthedocs.build/pep-0594/"
+    assert pep_url == expected_url


### PR DESCRIPTION
If you leave it out, it'll open the root homepage.

```console
$ pep
https://peps.python.org
$ pep --pr 2440
https://pep-previews--2440.org.readthedocs.build
$ pep -p 2440
https://pep-previews--2440.org.readthedocs.build
```

Also allow `-p` for `--pr` (doubling productivity!).