### PR TITLE
Allow searching multiple words without wrapping in quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ https://peps.python.org/pep-0664/
 
 ### Open a PEP by searching for words in the title
 
-<!-- [[[cog run('pep "dead batteries"') ]]] -->
+<!-- [[[cog run("pep dead batteries") ]]] -->
 
 ```console
-$ pep "dead batteries"
+$ pep dead batteries
 Score	Result
 90	PEP 594: Removing dead batteries from the standard library
 55	PEP 288: Generators Attributes and Exceptions
@@ -108,7 +108,7 @@ https://pep-previews--2440.org.readthedocs.build
 
 ```console
 $ pep --help
-usage: pep [-h] [-u URL] [-p PR] [-n] [--clear-cache] [-v] [-V] [search]
+usage: pep [-h] [-u URL] [-p PR] [-n] [--clear-cache] [-v] [-V] [search ...]
 
 pepotron: CLI to open PEPs in your browser
 

--- a/src/pepotron/cli.py
+++ b/src/pepotron/cli.py
@@ -16,7 +16,7 @@ def main() -> None:
     )
     parser.add_argument(
         "search",
-        nargs="?",
+        nargs="*",
         help="PEP number, or Python version for its schedule, or words from title",
     )
     parser.add_argument(
@@ -44,6 +44,8 @@ def main() -> None:
     args = parser.parse_args()
 
     logging.basicConfig(level=args.loglevel)
+    if args.search:
+        args.search = " ".join(args.search)
     if args.clear_cache:
         _cache.clear(clear_all=True)
 


### PR DESCRIPTION
# Before

```console
$ pep -n "dead batteries"
Score	Result
90	PEP 594: Removing dead batteries from the standard library
55	PEP 288: Generators Attributes and Exceptions
55	PEP 363: Syntax For Dynamic Attribute Access
55	PEP 476: Enabling certificate verification by default for stdlib http clients
52	PEP 349: Allow str() to return unicode strings

https://peps.python.org/pep-0594/
$ pep -n dead batteries
usage: pep [-h] [-u URL] [-p PR] [-n] [--clear-cache] [-v] [-V] [search]
pep: error: unrecognized arguments: batteries
```

# After

```console
$ pep -n "dead batteries"
Score	Result
90	PEP 594: Removing dead batteries from the standard library
55	PEP 288: Generators Attributes and Exceptions
55	PEP 363: Syntax For Dynamic Attribute Access
55	PEP 476: Enabling certificate verification by default for stdlib http clients
52	PEP 349: Allow str() to return unicode strings

https://peps.python.org/pep-0594/
$ pep -n dead batteries
Score	Result
90	PEP 594: Removing dead batteries from the standard library
55	PEP 288: Generators Attributes and Exceptions
55	PEP 363: Syntax For Dynamic Attribute Access
55	PEP 476: Enabling certificate verification by default for stdlib http clients
52	PEP 349: Allow str() to return unicode strings

https://peps.python.org/pep-0594/
```