### PR TITLE
docs: Add pipx to installation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pipx install pepotron
 ```bash
 git clone https://github.com/hugovk/pepotron
 cd pepotron
-pip install .
+python3 -m pip install .
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ CLI to open PEPs in your browser.
 python3 -m pip install --upgrade pepotron
 ```
 
+### With [pipx][pipx]
+
+```bash
+pipx install pepotron
+```
+
+[pipx]: https://github.com/pypa/pipx
+
 ### From source
 
 ```bash


### PR DESCRIPTION
Resolves #5 

Add `pipx` to the list of installation options and link to [the GitHub project page](https://github.com/pypa/pipx) for users who are not yet familiar with `pipx`.

I opted to not try to explain any more, as the other installation options are very brief and self explanatory (:+1:) and I didn't want to break that flow with adding additional information on `pipx` &mdash; I hope that any curious users will be interested enough to click on the link to the `pipx` project and go from there.