### PR TITLE
Remove redundant `wheel` dependency from `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "setuptools.build_meta"
 requires = [
   "setuptools>=45",
   "setuptools_scm[toml]>=6.2",
-  "wheel",
+
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ build-backend = "setuptools.build_meta"
 requires = [
   "setuptools>=45",
   "setuptools_scm[toml]>=6.2",
-
 ]
 
 [tool.black]


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos