### PR TITLE
Add `bpo` CLI to open redirect URLs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,14 @@
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "03:00"
+    open-pull-requests-limit: 10
+    labels:
+      - "changelog: skip"
+      - "dependencies"
   - package-ecosystem: pip
     directory: "/"
     schedule:
@@ -8,13 +17,4 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "changelog: skip"
-      - dependencies
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: monthly
-      time: "03:00"
-    open-pull-requests-limit: 10
-    labels:
-      - dependencies
-      - "changelog: skip"
+      - "dependencies"

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ https://pep-previews--2440.org.readthedocs.build
 
 ```console
 $ pep --help
-usage: pep [-h] [-u URL] [-p PR] [-n] [--clear-cache] [-v] [-V] [search ...]
+usage: pep [-h] [-u URL] [-p PR] [--clear-cache] [-n] [-v] [-V] [search ...]
 
 pepotron: CLI to open PEPs in your browser
 
@@ -128,8 +128,8 @@ options:
   -h, --help         show this help message and exit
   -u URL, --url URL  Base URL for PEPs (default: https://peps.python.org)
   -p PR, --pr PR     Open preview for python/peps PR
-  -n, --dry-run      Don't open in browser
   --clear-cache      Clear cache before running
+  -n, --dry-run      Don't open in browser
   -v, --verbose      Verbose logging
   -V, --version      show program's version number and exit
 ```

--- a/README.md
+++ b/README.md
@@ -110,6 +110,23 @@ https://pep-previews--2440.org.readthedocs.build
 
 <!-- [[[end]]] -->
 
+### Open a BPO issue in the browser
+
+Issues from [bugs.python.org](https://bugs.python.org/) have been migrated to
+[GitHub issues](https://github.com/python/cpython/issues) and have new numbers. This
+command will open the redirect page to take you to the new issue.
+
+<!-- [[[cog run("bpo 46208") ]]] -->
+
+```console
+$ bpo 46208
+https://bugs.python.org/issue?@action=redirect&bpo=46208
+```
+
+<!-- [[[end]]] -->
+
+This redirects to https://github.com/python/cpython/issues/90366
+
 ### Help
 
 <!-- [[[cog run("pep --help") ]]] -->

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
     Programming Language :: Python :: Implementation :: PyPy
 keywords =
     pep
+    bpo
     cli
 project_urls =
     Source=https://github.com/hugovk/pepotron
@@ -49,6 +50,7 @@ where = src
 [options.entry_points]
 console_scripts =
     pep = pepotron.cli:main
+    bpo = pepotron.cli:bpo
 
 [options.extras_require]
 tests =

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 
-def local_scheme(version) -> str:
+def local_scheme(version: str) -> str:
     """Skip the local version (e.g. +xyz of 0.6.1.dev4+gdf99fe2)
     to be able to upload to Test PyPI"""
     return ""

--- a/src/pepotron/__init__.py
+++ b/src/pepotron/__init__.py
@@ -131,3 +131,14 @@ def pep(
 
         webbrowser.open_new_tab(pep_url)
     print(pep_url)
+
+
+def open_bpo(number: int, dry_run: bool = False) -> str:
+    """Open this BPO in the browser"""
+    bpo_url = f"https://bugs.python.org/issue?@action=redirect&bpo={number}"
+    if not dry_run:
+        import webbrowser
+
+        webbrowser.open_new_tab(bpo_url)
+    print(bpo_url)
+    return bpo_url

--- a/src/pepotron/__init__.py
+++ b/src/pepotron/__init__.py
@@ -68,6 +68,7 @@ def _download_peps_json() -> Path:
 
         _cache.save(cache_file, res)
 
+    logging.info("")
     return cache_file
 
 

--- a/src/pepotron/__init__.py
+++ b/src/pepotron/__init__.py
@@ -97,7 +97,7 @@ def word_search(search: str | None) -> int:
     return int(result[0][0][0])
 
 
-def url(search: str | None, base_url: str = BASE_URL, pr: int | None = None) -> str:
+def pep_url(search: str | None, base_url: str = BASE_URL, pr: int | None = None) -> str:
     """Get PEP URL"""
     if pr:
         base_url = f"https://pep-previews--{pr}.org.readthedocs.build"
@@ -121,24 +121,25 @@ def url(search: str | None, base_url: str = BASE_URL, pr: int | None = None) -> 
     return result
 
 
-def pep(
+def open_pep(
     search: str, base_url: str = BASE_URL, pr: int | None = None, dry_run: bool = False
-) -> None:
+) -> str:
     """Open this PEP in the browser"""
-    pep_url = url(search, base_url, pr)
+    url = pep_url(search, base_url, pr)
     if not dry_run:
         import webbrowser
 
-        webbrowser.open_new_tab(pep_url)
-    print(pep_url)
+        webbrowser.open_new_tab(url)
+    print(url)
+    return url
 
 
 def open_bpo(number: int, dry_run: bool = False) -> str:
     """Open this BPO in the browser"""
-    bpo_url = f"https://bugs.python.org/issue?@action=redirect&bpo={number}"
+    url = f"https://bugs.python.org/issue?@action=redirect&bpo={number}"
     if not dry_run:
         import webbrowser
 
-        webbrowser.open_new_tab(bpo_url)
-    print(bpo_url)
-    return bpo_url
+        webbrowser.open_new_tab(url)
+    print(url)
+    return url

--- a/src/pepotron/cli.py
+++ b/src/pepotron/cli.py
@@ -5,9 +5,28 @@ import argparse
 import atexit
 import logging
 
-from pepotron import BASE_URL, __version__, _cache, open_bpo, pep
+from pepotron import BASE_URL, __version__, _cache, open_bpo, open_pep
 
 atexit.register(_cache.clear)
+
+
+def add_common_arguments(parser):
+    parser.add_argument(
+        "-n", "--dry-run", action="store_true", help="Don't open in browser"
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_const",
+        dest="loglevel",
+        const=logging.INFO,
+        default=logging.WARNING,
+        help="Verbose logging",
+    )
+    parser.add_argument(
+        "-V", "--version", action="version", version=f"%(prog)s {__version__}"
+    )
+    return parser
 
 
 def main() -> None:
@@ -24,23 +43,9 @@ def main() -> None:
     )
     parser.add_argument("-p", "--pr", type=int, help="Open preview for python/peps PR")
     parser.add_argument(
-        "-n", "--dry-run", action="store_true", help="Don't open in browser"
-    )
-    parser.add_argument(
         "--clear-cache", action="store_true", help="Clear cache before running"
     )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_const",
-        dest="loglevel",
-        const=logging.INFO,
-        default=logging.WARNING,
-        help="Verbose logging",
-    )
-    parser.add_argument(
-        "-V", "--version", action="version", version=f"%(prog)s {__version__}"
-    )
+    parser = add_common_arguments(parser)
     args = parser.parse_args()
 
     logging.basicConfig(level=args.loglevel, format="%(message)s")
@@ -49,7 +54,7 @@ def main() -> None:
     if args.clear_cache:
         _cache.clear(clear_all=True)
 
-    pep(search=args.search, base_url=args.url, pr=args.pr, dry_run=args.dry_run)
+    open_pep(search=args.search, base_url=args.url, pr=args.pr, dry_run=args.dry_run)
 
 
 def bpo() -> None:
@@ -57,21 +62,7 @@ def bpo() -> None:
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument("bpo", type=int, help="BPO number")
-    parser.add_argument(
-        "-n", "--dry-run", action="store_true", help="Don't open in browser"
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_const",
-        dest="loglevel",
-        const=logging.INFO,
-        default=logging.WARNING,
-        help="Verbose logging",
-    )
-    parser.add_argument(
-        "-V", "--version", action="version", version=f"%(prog)s {__version__}"
-    )
+    parser = add_common_arguments(parser)
     args = parser.parse_args()
 
     logging.basicConfig(level=args.loglevel, format="%(message)s")

--- a/src/pepotron/cli.py
+++ b/src/pepotron/cli.py
@@ -5,7 +5,7 @@ import argparse
 import atexit
 import logging
 
-from pepotron import BASE_URL, __version__, _cache, pep
+from pepotron import BASE_URL, __version__, _cache, open_bpo, pep
 
 atexit.register(_cache.clear)
 
@@ -50,6 +50,32 @@ def main() -> None:
         _cache.clear(clear_all=True)
 
     pep(search=args.search, base_url=args.url, pr=args.pr, dry_run=args.dry_run)
+
+
+def bpo() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("bpo", type=int, help="BPO number")
+    parser.add_argument(
+        "-n", "--dry-run", action="store_true", help="Don't open in browser"
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_const",
+        dest="loglevel",
+        const=logging.INFO,
+        default=logging.WARNING,
+        help="Verbose logging",
+    )
+    parser.add_argument(
+        "-V", "--version", action="version", version=f"%(prog)s {__version__}"
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=args.loglevel, format="%(message)s")
+    open_bpo(number=args.bpo, dry_run=args.dry_run)
 
 
 if __name__ == "__main__":

--- a/src/pepotron/cli.py
+++ b/src/pepotron/cli.py
@@ -59,7 +59,8 @@ def main() -> None:
 
 def bpo() -> None:
     parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+        description="Open this BPO in the browser",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("bpo", type=int, help="BPO number")
     parser = add_common_arguments(parser)

--- a/src/pepotron/cli.py
+++ b/src/pepotron/cli.py
@@ -43,7 +43,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    logging.basicConfig(level=args.loglevel)
+    logging.basicConfig(level=args.loglevel, format="%(message)s")
     if args.search:
         args.search = " ".join(args.search)
     if args.clear_cache:

--- a/tests/test_pepotron.py
+++ b/tests/test_pepotron.py
@@ -18,7 +18,7 @@ import pepotron
 )
 def test_url(search: str, expected_url: str) -> None:
     # Act
-    pep_url = pepotron.url(search)
+    pep_url = pepotron.pep_url(search)
     # Assert
     assert pep_url == expected_url
 
@@ -50,7 +50,7 @@ def test_url(search: str, expected_url: str) -> None:
 )
 def test_url_base_url(search: str, base_url: str, expected_url: str) -> None:
     # Act
-    pep_url = pepotron.url(search, base_url)
+    pep_url = pepotron.pep_url(search, base_url)
     # Assert
     assert pep_url == expected_url
 
@@ -66,13 +66,14 @@ def test_url_pr(search, expected_url) -> None:
     # Arrange
     pr = 2440
     # Act
-    pep_url = pepotron.url(search, pr=pr)
+    pep_url = pepotron.pep_url(search, pr=pr)
     # Assert
     assert pep_url == expected_url
 
 
 def test_pep() -> None:
-    pepotron.pep("8", dry_run=True)
+    url = pepotron.open_pep("8", dry_run=True)
+    assert url == "https://peps.python.org/pep-0008/"
 
 
 def test_open_bpo() -> None:

--- a/tests/test_pepotron.py
+++ b/tests/test_pepotron.py
@@ -73,3 +73,8 @@ def test_url_pr(search, expected_url) -> None:
 
 def test_pep() -> None:
     pepotron.pep("8", dry_run=True)
+
+
+def test_open_bpo() -> None:
+    url = pepotron.open_bpo(38374, dry_run=True)
+    assert url == "https://bugs.python.org/issue?@action=redirect&bpo=38374"

--- a/tox.ini
+++ b/tox.ini
@@ -25,4 +25,4 @@ skip_install = true
 deps =
     pre-commit
 commands =
-    pre-commit run --all-files
+    pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
### Open a bpo in the browser

Issues from [bugs.python.org](https://bugs.python.org/) have been migrated to [GitHub issues](https://github.com/python/cpython/issues) and have new numbers.

This command will open the redirect page to take you to the new issue.

<!-- [[[cog run("bpo 46208") ]]] -->

```console
$ bpo 46208
https://bugs.python.org/issue?@action=redirect&bpo=46208
```

This redirects to https://github.com/python/cpython/issues/90366
