### PR TITLE
Open topics index for `pep topic` or `pep topics`

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ https://peps.python.org/topic/typing/
 
 <!-- [[[end]]] -->
 
+<!-- [[[cog run("pep topics") ]]] -->
+
+```console
+$ pep topics
+https://peps.python.org/topic/
+```
+
+<!-- [[[end]]] -->
+
 ### Open a build preview of a python/peps PR
 
 <!-- [[[cog run("pep 594 --pr 2440") ]]] -->

--- a/README.md
+++ b/README.md
@@ -90,6 +90,33 @@ https://peps.python.org/topic/governance/
 
 <!-- [[[end]]] -->
 
+<!-- [[[cog run("pep packaging") ]]] -->
+
+```console
+$ pep packaging
+https://peps.python.org/topic/packaging/
+```
+
+<!-- [[[end]]] -->
+
+<!-- [[[cog run("pep release") ]]] -->
+
+```console
+$ pep release
+https://peps.python.org/topic/release/
+```
+
+<!-- [[[end]]] -->
+
+<!-- [[[cog run("pep typing") ]]] -->
+
+```console
+$ pep typing
+https://peps.python.org/topic/typing/
+```
+
+<!-- [[[end]]] -->
+
 ### Open a build preview of a python/peps PR
 
 <!-- [[[cog run("pep 594 --pr 2440") ]]] -->

--- a/src/pepotron/__init__.py
+++ b/src/pepotron/__init__.py
@@ -107,6 +107,8 @@ def pep_url(search: str | None, base_url: str = BASE_URL, pr: int | None = None)
     result = base_url.rstrip("/")
 
     if search:
+        if search.lower() in ("topic", "topics"):
+            return result + "/topic/"
         if search.lower() in TOPICS:
             result += f"/topic/{search}/"
             return result

--- a/src/pepotron/__init__.py
+++ b/src/pepotron/__init__.py
@@ -106,27 +106,27 @@ def pep_url(search: str | None, base_url: str = BASE_URL, pr: int | None = None)
 
     result = base_url.rstrip("/")
 
-    if search:
-        if search.lower() in ("topic", "topics"):
-            return result + "/topic/"
-        if search.lower() in TOPICS:
-            result += f"/topic/{search}/"
-            return result
+    if not search:
+        return result
 
+    if search.lower() in ("topic", "topics"):
+        return result + "/topic/"
+
+    if search.lower() in TOPICS:
+        return result + f"/topic/{search}/"
+
+    try:
+        # pep 8
+        number = int(search)
+    except ValueError:
         try:
-            # pep 8
-            number = int(search)
-        except ValueError:
-            try:
-                # pep 3.11
-                number = VERSION_TO_PEP[search]
-            except KeyError:
-                # pep "dead batteries"
-                number = word_search(search)
+            # pep 3.11
+            number = VERSION_TO_PEP[search]
+        except KeyError:
+            # pep "dead batteries"
+            number = word_search(search)
 
-        result += f"/pep-{number:0>4}/"
-
-    return result
+    return result + f"/pep-{number:0>4}/"
 
 
 def open_pep(

--- a/tests/test_pepotron.py
+++ b/tests/test_pepotron.py
@@ -18,6 +18,8 @@ import pepotron
         ("dead batteries", "https://peps.python.org/pep-0594/"),
         ("release", "https://peps.python.org/topic/release/"),
         ("typing", "https://peps.python.org/topic/typing/"),
+        ("topics", "https://peps.python.org/topic/"),
+        ("topic", "https://peps.python.org/topic/"),
     ],
 )
 def test_url(search: str, expected_url: str) -> None:


### PR DESCRIPTION
Open topics index for `pep topic` or `pep topics`:

```console
$ pep topic
https://peps.python.org/topic/
$ pep topics
https://peps.python.org/topic/
```

Also, following on from https://github.com/hugovk/pepotron/pull/32: there's only four topics, let's show them all in the README.