### PR TITLE
Replace deprecated `utcnow()` with `now(utc)`

### DIFF
--- a/src/pepotron/_cache.py
+++ b/src/pepotron/_cache.py
@@ -27,7 +27,7 @@ def filename(url: str) -> Path:
     """yyyy-mm-dd-url-slug.json"""
     from slugify import slugify
 
-    today = dt.datetime.utcnow().strftime("%Y-%m-%d")
+    today = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
     slug = slugify(url)
     return CACHE_DIR / f"{today}-{slug}.json"
 
@@ -63,7 +63,7 @@ def save(cache_file: Path, data: PepData) -> None:
 def clear(clear_all: bool = False) -> None:
     """Delete all or old cache files"""
     cache_files = CACHE_DIR.glob("**/*.json")
-    today = dt.datetime.utcnow().strftime("%Y-%m-%d")
+    today = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
     for cache_file in cache_files:
         if clear_all or not cache_file.name.startswith(today):
             cache_file.unlink()


### PR DESCRIPTION
Will raise a deprecation warning in 3.12: https://github.com/python/cpython/issues/103857.