### PR TITLE
Replace httpx with urllib3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
       - id: mypy
         args: [--strict, --pretty, --show-error-codes]
         additional_dependencies:
-          [httpx, platformdirs, pytest, types-freezegun, types-python-slugify]
+          [platformdirs, pytest, types-freezegun, types-python-slugify, urllib3]
 
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: 0.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,10 +37,10 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "httpx>=0.22",
   "platformdirs",
   "python-slugify",
   "thefuzz",
+  "urllib3>=2",
 ]
 [project.optional-dependencies]
 tests = [

--- a/tests/test_pepotron.py
+++ b/tests/test_pepotron.py
@@ -77,6 +77,20 @@ def test_url_pr(search: str | None, expected_url: str) -> None:
     assert pep_url == expected_url
 
 
+def test__download_peps_json_ok() -> None:
+    # Arrange
+    pepotron._cache.clear(clear_all=True)
+    # Act
+    filename = pepotron._download_peps_json()
+    # Assert
+    assert filename.suffix == ".json"
+
+
+def test__download_peps_json_error() -> None:
+    with pytest.raises(RuntimeError):
+        pepotron._download_peps_json("https://httpstat.us/404")
+
+
 def test_pep() -> None:
     url = pepotron.open_pep("8", dry_run=True)
     assert url == "https://peps.python.org/pep-0008/"


### PR DESCRIPTION
https://github.com/urllib3/urllib3/ is a lighter package than https://github.com/encode/httpx/ and we're only doing a maximum of a single request.

# Size

Comparing venvs installing each library and removing common files:
```console
$ du -sh venv-*
3.9M	venv-httpx
988K	venv-urllib3
```

![image](https://github.com/hugovk/pepotron/assets/1324225/4dd65a1d-894c-4c26-9b88-2c94e3c7c705)

# Import time

Here's how to use `python -X importtime` and tuna to identify bottlenecks: https://medium.com/alan/how-we-improved-our-python-backend-start-up-time-2c33cd4873c8

Running:

```
python -X importtime -c "import pepotron; pepotron._cache.clear(clear_all=True); pepotron._download_peps_json()" 2> import.log
tuna import.log
```

## httpx

httpx takes 0.082s (62.4%) of total 0.131s import time:

![image](https://github.com/hugovk/pepotron/assets/1324225/a5927dd9-bcd3-4afc-8f59-71b9903ff8b0)

## urllib3

urllib3 takes 0.017s (21.3%) of total 0.081s import time:

![image](https://github.com/hugovk/pepotron/assets/1324225/681780a3-893d-4cbb-9743-2d306e653fa1)

urllib3's rich.console import alone (0.042s, 32.3%) takes more than all of urllib3.

Well, these are all small numbers, but it can help to shave off some for CLIs, and these are both good libraries. One of the [Command Line Interface Guidelines](https://clig.dev/#robustness-guidelines):

> **Responsive is more important than fast.** Print something to the user in <100ms. If you’re making a network request, print something before you do it so it doesn’t hang and look broken.
