### PR TITLE
Add `pep next` command to find the next available number

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,6 +11,10 @@ exclude_lines =
     def main
 
     if TYPE_CHECKING:
+    if not dry_run:
+
+    except ImportError:
+    except OSError:
 
 [run]
 omit =

--- a/.coveragerc
+++ b/.coveragerc
@@ -9,6 +9,7 @@ exclude_lines =
     # Don't complain if non-runnable code isn't run:
     if __name__ == .__main__.:
     def main
+    def _get_github_prs
 
     if TYPE_CHECKING:
     if not dry_run:

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-max_line_length = 88
+max-line-length = 88

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.8.0
+    rev: v3.13.0
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
 
-  - repo: https://github.com/psf/black
-    rev: 23.3.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.1
     hooks:
       - id: black
 
@@ -17,31 +17,32 @@ repos:
         args: [--add-import=from __future__ import annotations]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
         additional_dependencies:
-          [flake8-2020, flake8-errmsg, flake8-implicit-str-concat]
+          [flake8-2020, flake8-errmsg, flake8-implicit-str-concat, flake8-logging]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
       - id: python-check-blanket-noqa
-      - id: python-no-log-warn
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
       - id: check-case-conflict
+      - id: check-executables-have-shebangs
       - id: check-merge-conflict
       - id: check-json
       - id: check-toml
       - id: check-yaml
+      - id: debug-statements
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.1
+    rev: v1.5.1
     hooks:
       - id: mypy
         args: [--strict, --pretty, --show-error-codes]
@@ -56,13 +57,13 @@ repos:
           ]
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 0.13.0
+    rev: 1.1.0
     hooks:
       - id: pyproject-fmt
         additional_dependencies: [tox]
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.13
+    rev: v0.14
     hooks:
       - id: validate-pyproject
 
@@ -72,7 +73,7 @@ repos:
       - id: tox-ini-fmt
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0
+    rev: v3.0.3
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]

--- a/README.md
+++ b/README.md
@@ -157,6 +157,20 @@ https://pep-previews--2440.org.readthedocs.build
 
 <!-- [[[end]]] -->
 
+### Find the next available PEP number
+
+Check published PEPs and [open PRs](https://github.com/python/peps/pulls) to find the
+next available PEP number.
+
+<!-- [[[cog run("pep next") ]]] -->
+
+```console
+$ pep next
+Next available PEP: 730
+```
+
+<!-- [[[end]]] -->
+
 ### Open a BPO issue in the browser
 
 Issues from [bugs.python.org](https://bugs.python.org/) have been migrated to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
+  "ghapi",
   "platformdirs",
   "python-slugify",
   "rapidfuzz",

--- a/src/pepotron/__init__.py
+++ b/src/pepotron/__init__.py
@@ -10,19 +10,6 @@ from typing import Any
 
 from . import _cache
 
-try:
-    # Python 3.10+
-    from itertools import pairwise
-except ImportError:
-    # Python 3.9 and below
-    def pairwise(iterable):  # type: ignore
-        from itertools import tee
-
-        a, b = tee(iterable)
-        next(b, None)
-        return zip(a, b)
-
-
 __version__ = importlib.metadata.version(__name__)
 
 BASE_URL = "https://peps.python.org"
@@ -101,6 +88,18 @@ def _get_published_peps() -> set[int]:
 
 
 def _next_available_pep() -> int:
+    try:
+        # Python 3.10+
+        from itertools import pairwise
+    except ImportError:
+        # Python 3.9 and below
+        def pairwise(iterable):  # type: ignore
+            from itertools import tee
+
+            a, b = tee(iterable)
+            next(b, None)
+            return zip(a, b)
+
     published = _get_published_peps()
     proposed = _get_pr_peps()
     combined = published | proposed

--- a/src/pepotron/__init__.py
+++ b/src/pepotron/__init__.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import importlib.metadata
 import logging
 from pathlib import Path
+from typing import Any
 
 from . import _cache
 
@@ -117,18 +118,20 @@ def _next_available_pep() -> int:
     return next_pep
 
 
-def _get_pr_peps() -> set[int]:
-    import re
-
+def _get_github_prs() -> list[Any]:
     from ghapi.all import GhApi  # type: ignore
 
     api = GhApi(owner="python", repo="peps", authenticate=False)
-    prs = api.pulls.list()
+    return api.pulls.list()  # type: ignore[no-any-return]
+
+
+def _get_pr_peps() -> set[int]:
+    import re
 
     pr_title_regex = re.compile(r"^PEP (\d+): .*")
 
     numbers = set()
-    for pr in prs:
+    for pr in _get_github_prs():
         if match := re.search(pr_title_regex, pr.title):
             number = match[1]
             numbers.add(int(number))

--- a/src/pepotron/__init__.py
+++ b/src/pepotron/__init__.py
@@ -121,7 +121,7 @@ def _get_github_prs() -> list[Any]:
     from ghapi.all import GhApi  # type: ignore
 
     api = GhApi(owner="python", repo="peps", authenticate=False)
-    return api.pulls.list()  # type: ignore[no-any-return]
+    return api.pulls.list(per_page=100)  # type: ignore[no-any-return]
 
 
 def _get_pr_peps() -> set[int]:

--- a/src/pepotron/__init__.py
+++ b/src/pepotron/__init__.py
@@ -58,7 +58,7 @@ VERSION_TO_PEP = {
 
 def _download_peps_json(json_url: str = BASE_URL + JSON_PATH) -> Path:
     cache_file = _cache.filename(json_url)
-    logging.info(f"Cache file: {cache_file}")
+    logging.info("Cache file: %s", cache_file)
 
     data = _cache.load(cache_file)
     if data == {}:
@@ -69,7 +69,7 @@ def _download_peps_json(json_url: str = BASE_URL + JSON_PATH) -> Path:
 
         # Raise if we made a bad request
         # (4XX client error or 5XX server error response)
-        logging.info(f"HTTP status code: {resp.status}")
+        logging.info("HTTP status code: %s", resp.status)
         if resp.status != 200:
             msg = f"Unable to download {json_url}: status {resp.status}"
             raise RuntimeError(msg)

--- a/src/pepotron/__init__.py
+++ b/src/pepotron/__init__.py
@@ -7,7 +7,20 @@ import importlib.metadata
 import logging
 from pathlib import Path
 
-from pepotron import _cache
+from . import _cache
+
+try:
+    # Python 3.10+
+    from itertools import pairwise
+except ImportError:
+    # Python 3.9 and below
+    def pairwise(iterable):  # type: ignore
+        from itertools import tee
+
+        a, b = tee(iterable)
+        next(b, None)
+        return zip(a, b)
+
 
 __version__ = importlib.metadata.version(__name__)
 
@@ -69,15 +82,64 @@ def _download_peps_json(json_url: str = BASE_URL + JSON_PATH) -> Path:
     return cache_file
 
 
-def word_search(search: str | None) -> int:
+def _get_peps() -> _cache.PepData:
     import json
 
     peps_file = _download_peps_json()
 
+    with open(peps_file) as f:
+        peps: _cache.PepData = json.load(f)
+
+    return peps
+
+
+def _get_published_peps() -> set[int]:
+    peps = _get_peps()
+    numbers = {int(number) for number, details in peps.items()}
+    return numbers
+
+
+def _next_available_pep() -> int:
+    published = _get_published_peps()
+    proposed = _get_pr_peps()
+    combined = published | proposed
+    numbers = sorted(combined)
+
+    start = 400
+    next_pep = -1
+    for x, y in pairwise(numbers):
+        if x < start:
+            continue
+        if x + 1 != y:
+            next_pep = x + 1
+            break
+
+    return next_pep
+
+
+def _get_pr_peps() -> set[int]:
+    import re
+
+    from ghapi.all import GhApi  # type: ignore
+
+    api = GhApi(owner="python", repo="peps", authenticate=False)
+    prs = api.pulls.list()
+
+    pr_title_regex = re.compile(r"^PEP (\d+): .*")
+
+    numbers = set()
+    for pr in prs:
+        if match := re.search(pr_title_regex, pr.title):
+            number = match[1]
+            numbers.add(int(number))
+
+    return numbers
+
+
+def word_search(search: str | None) -> int:
     from rapidfuzz import process
 
-    with open(peps_file) as f:
-        peps = json.load(f)
+    peps = _get_peps()
 
     # Dict of title->number
     titles = {details["title"]: number for number, details in peps.items()}
@@ -89,11 +151,11 @@ def word_search(search: str | None) -> int:
     print()
 
     # Find PEP number of top match
-    number: int = next(
+    number: str = next(
         number for number, details in peps.items() if details["title"] == result[0][0]
     )
 
-    return number
+    return int(number)
 
 
 def pep_url(search: str | None, base_url: str = BASE_URL, pr: int | None = None) -> str:
@@ -111,6 +173,9 @@ def pep_url(search: str | None, base_url: str = BASE_URL, pr: int | None = None)
 
     if search.lower() in TOPICS:
         return result + f"/topic/{search}/"
+
+    if search.lower() == "next":
+        return f"Next available PEP: {_next_available_pep()}"
 
     try:
         # pep 8

--- a/src/pepotron/cli.py
+++ b/src/pepotron/cli.py
@@ -7,7 +7,7 @@ import argparse
 import atexit
 import logging
 
-from pepotron import BASE_URL, __version__, _cache, open_bpo, open_pep
+from . import BASE_URL, __version__, _cache, open_bpo, open_pep
 
 atexit.register(_cache.clear)
 

--- a/tests/test_pepotron.py
+++ b/tests/test_pepotron.py
@@ -3,6 +3,8 @@ Unit tests
 """
 from __future__ import annotations
 
+from collections import namedtuple
+
 import pytest
 
 import pepotron
@@ -30,12 +32,21 @@ def test_url(search: str, expected_url: str) -> None:
 
 
 def test_next() -> None:
+    # Arrange
+    Pull = namedtuple("Pull", ["title"])
+    prs = [
+        Pull(title="PEP 716: Seven One Six"),
+        Pull(title="PEP 717: Seven One Seven"),
+    ]
+    # mock _get_github_prs:
+    pepotron._get_github_prs = lambda: prs
+
     # Act
-    pep_url = pepotron.pep_url("next")
+    next_pep = pepotron.pep_url("next")
 
     # Assert
-    assert pep_url.startswith("Next available PEP: ")
-    assert pep_url.split()[-1].isdigit()
+    assert next_pep.startswith("Next available PEP: ")
+    assert next_pep.split()[-1].isdigit()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pepotron.py
+++ b/tests/test_pepotron.py
@@ -29,6 +29,15 @@ def test_url(search: str, expected_url: str) -> None:
     assert pep_url == expected_url
 
 
+def test_next() -> None:
+    # Act
+    pep_url = pepotron.pep_url("next")
+
+    # Assert
+    assert pep_url.startswith("Next available PEP: ")
+    assert pep_url.split()[-1].isdigit()
+
+
 @pytest.mark.parametrize(
     "search, base_url, expected_url",
     [

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,13 @@ env_list =
 extras =
     tests
 commands =
-    {envpython} -m pytest --cov pepotron --cov tests --cov-report html --cov-report term --cov-report xml {posargs}
+    {envpython} -m pytest \
+      --cov pepotron \
+      --cov tests \
+      --cov-report html \
+      --cov-report term \
+      --cov-report xml \
+      {posargs}
     pep --version
     pep --help
 


### PR DESCRIPTION
It checks the published PEPs at https://peps.python.org/api/peps.json, and open PRs beginning "PEP xxx: " at https://github.com/python/peps/pulls, combines them, then goes through them to find the first available number.

And we start at 400, because there's some unassigned numbers below this:

- 14 -> 19
- 21 -> 41
- 43 -> 99
- 104 -> 159
- 161 -> 199
- 300
- 388


For example:

```console
❯ pep next
Next available PEP: 730
```

