### PR TITLE
Don't attempt to open output of `pep next` in browser

### DIFF
--- a/src/pepotron/__init__.py
+++ b/src/pepotron/__init__.py
@@ -198,7 +198,7 @@ def open_pep(
 ) -> str:
     """Open this PEP in the browser"""
     url = pep_url(search, base_url, pr)
-    if not dry_run:
+    if not dry_run and "Next available PEP: " not in url:
         import webbrowser
 
         webbrowser.open_new_tab(url)


### PR DESCRIPTION
For some reason, this never happened to me on macOS even though I was initially expecting it.

But it does occur on Linux:

`pep next` opens `file:///home/username/python/main/Next%20available%20PEP:%20731` URL in a browser. This URL doesn't exist.

Don't attempt to open such output.