### PR TITLE
Document `pep next` in `--help`

### DIFF
--- a/src/pepotron/cli.py
+++ b/src/pepotron/cli.py
@@ -38,7 +38,8 @@ def main() -> None:
     parser.add_argument(
         "search",
         nargs="*",
-        help="PEP number, or Python version for its schedule, or words from title",
+        help="PEP number, or Python version for its schedule, or words from title, "
+        "or 'next' to find next available PEP number",
     )
     parser.add_argument(
         "-u", "--url", default=BASE_URL, help=f"Base URL for PEPs (default: {BASE_URL})"


### PR DESCRIPTION
Fixes #52.

# Before

```console
❯ pep --help
usage: pep [-h] [-u URL] [-p PR] [--clear-cache] [-n] [-v] [-V] [search ...]

pepotron: CLI to open PEPs in your browser

positional arguments:
  search             PEP number, or Python version for its schedule, or words
                     from title

options:
  -h, --help         show this help message and exit
  -u URL, --url URL  Base URL for PEPs (default: https://peps.python.org)
  -p PR, --pr PR     Open preview for python/peps PR
  --clear-cache      Clear cache before running
  -n, --dry-run      Don't open in browser
  -v, --verbose      Verbose logging
  -V, --version      show program's version number and exit
```

# After

```console
❯ pep --help
usage: pep [-h] [-u URL] [-p PR] [--clear-cache] [-n] [-v] [-V] [search ...]

pepotron: CLI to open PEPs in your browser

positional arguments:
  search             PEP number, or Python version for its schedule, or words
                     from title, or 'next' to find next available PEP number

options:
  -h, --help         show this help message and exit
  -u URL, --url URL  Base URL for PEPs (default: https://peps.python.org)
  -p PR, --pr PR     Open preview for python/peps PR
  --clear-cache      Clear cache before running
  -n, --dry-run      Don't open in browser
  -v, --verbose      Verbose logging
  -V, --version      show program's version number and exit
```