### PR TITLE
Fix CI: Python 3.8 and 3.9 are on macos-13 but not macos-latest (macos-14-arm64)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,12 @@ name: Test
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: 1
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U wheel
           python -m pip install -U tox
 
       - name: Tox tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,17 @@ env:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: "${{ matrix.os }}-${{ matrix.os-version || 'latest' }}"
     strategy:
       fail-fast: false
       matrix:
         python-version: ["pypy3.10", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [Windows, macOS, Ubuntu]
+        # Python 3.8 and 3.9 are on macos-13 but not macos-latest (macos-14-arm64)
+        # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
+        include:
+          - { python-version: "3.8", os: "macOS", os-version: "13" }
+          - { python-version: "3.9", os: "macOS", os-version: "13" }
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
           tox -e cog
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3.1.5
         with:
           flags: ${{ matrix.os }}
           name: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,19 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.5
+    rev: v0.4.1
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.3.0
+    rev: 24.4.0
     hooks:
       - id: black
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
+      - id: check-added-large-files
       - id: check-case-conflict
       - id: check-merge-conflict
       - id: check-json
@@ -20,7 +21,19 @@ repos:
       - id: check-yaml
       - id: debug-statements
       - id: end-of-file-fixer
+      - id: forbid-submodules
       - id: trailing-whitespace
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.28.2
+    hooks:
+      - id: check-github-workflows
+      - id: check-renovate
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.6.27
+    hooks:
+      - id: actionlint
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.9.0
@@ -31,7 +44,7 @@ repos:
           [platformdirs, pytest, python-slugify, rapidfuzz, types-freezegun, urllib3]
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 1.7.0
+    rev: 1.8.0
     hooks:
       - id: pyproject-fmt
         additional_dependencies: [tox]

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,6 @@ commands =
     pep --dry-run 8
     pep --dry-run 3.13
     pep --dry-run dead batteries
-    pep next
 
 [testenv:cog]
 deps =


### PR DESCRIPTION
Re: https://github.com/actions/setup-python/issues/696#issuecomment-1637587760

Based on @nedbat's method: https://github.com/nedbat/coveragepy/commit/41e01d3ef0f98ec256173fd1864488cc72ab6f73

Also some other config updates; see commits.