### PR TITLE
Generate `__version__` at build to avoid slow `importlib.metadata`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,9 +21,17 @@ jobs:
           cache: pip
       - uses: pre-commit/action@v3.0.1
 
+  mypy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          cache: pip
       - name: Install dependencies
         run: |
           python3 -m pip install -U tox
-
       - name: Mypy
         run: tox -e mypy

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 env:
   FORCE_COLOR: 1
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
 
 permissions:
   contents: read
@@ -17,4 +18,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+          cache: pip
       - uses: pre-commit/action@v3.0.1
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install -U tox
+
+      - name: Mypy
+        run: tox -e mypy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,17 +11,12 @@ env:
 
 jobs:
   test:
-    runs-on: "${{ matrix.os }}-${{ matrix.os-version || 'latest' }}"
+    runs-on: "${{ matrix.os }}-latest"
     strategy:
       fail-fast: false
       matrix:
         python-version: ["pypy3.10", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [Windows, macOS, Ubuntu]
-        # Python 3.8 and 3.9 are on macos-13 but not macos-latest (macos-14-arm64)
-        # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
-        include:
-          - { python-version: "3.8", os: "macOS", os-version: "13" }
-          - { python-version: "3.9", os: "macOS", os-version: "13" }
 
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+# hatch-vcs
+src/*/_version.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,14 +35,6 @@ repos:
     hooks:
       - id: actionlint
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
-    hooks:
-      - id: mypy
-        args: [--strict, --pretty, --show-error-codes]
-        additional_dependencies:
-          [platformdirs, pytest, python-slugify, rapidfuzz, types-freezegun, urllib3]
-
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: 2.2.1
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ scripts.pep = "pepotron.cli:main"
 [tool.hatch]
 version.source = "vcs"
 
+[tool.hatch.build.hooks.vcs]
+version-file = "src/pepotron/_version.py"
+
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
 

--- a/src/pepotron/__init__.py
+++ b/src/pepotron/__init__.py
@@ -4,14 +4,13 @@ CLI to open PEPs in your browser
 
 from __future__ import annotations
 
-import importlib.metadata
 import logging
 from pathlib import Path
 from typing import Any
 
-from . import _cache
+from . import _cache, _version
 
-__version__ = importlib.metadata.version(__name__)
+__version__ = _version.__version__
 
 BASE_URL = "https://peps.python.org"
 JSON_PATH = "/api/peps.json"

--- a/src/pepotron/__init__.py
+++ b/src/pepotron/__init__.py
@@ -119,7 +119,7 @@ def _next_available_pep() -> int:
 
 
 def _get_github_prs() -> list[Any]:
-    from ghapi.all import GhApi  # type: ignore[import-not-found]
+    from ghapi.all import GhApi  # type: ignore[import-untyped]
 
     api = GhApi(owner="python", repo="peps", authenticate=False)
     return api.pulls.list(per_page=100)  # type: ignore[no-any-return]

--- a/tox.ini
+++ b/tox.ini
@@ -41,3 +41,15 @@ pass_env =
     PRE_COMMIT_COLOR
 commands =
     pre-commit run --all-files --show-diff-on-failure
+
+[testenv:mypy]
+deps =
+    mypy==1.11.2
+    platformdirs
+    pytest
+    python-slugify
+    rapidfuzz
+    types-freezegun
+    urllib3
+commands =
+    mypy --strict --pretty --show-error-codes . {posargs}


### PR DESCRIPTION
Saves about 15 ms, about twice as fast.

```console
❯ python --version
Python 3.13.0rc1
❯ python -X importtime -c "import pepotron" 2> import.log && tuna import.log
```


Before:

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/cdd4b5fc-5893-4689-9bcf-3663ef8df5c9">

After:

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/9ac6696b-4f59-4c95-8d27-bfc901a54418">

Also move mypy from pre-commit to tox, because it's easier to run it against an installed project, so `_version` has been built.


```console
❯ hyperfine --warmup 32 \
--prepare "git checkout rm-importlib.metadata" 'python3 -c "import pepotron"' \
--prepare "git checkout main"                  'python3 -c "import    pepotron"'
Benchmark 1: python3 -c "import pepotron"
  Time (mean ± σ):      25.8 ms ±   1.1 ms    [User: 20.8 ms, System: 4.4 ms]
  Range (min … max):    24.6 ms …  30.3 ms    86 runs

Benchmark 2: python3 -c "import    pepotron"
  Time (mean ± σ):      41.6 ms ±   1.4 ms    [User: 34.2 ms, System: 6.8 ms]
  Range (min … max):    40.8 ms …  50.5 ms    47 runs

  Warning: The first benchmarking run for this command was significantly slower than the rest (50.5 ms). This could be caused by (filesystem) caches that were not filled until after the first run. You are already using both the '--warmup' option as well as the '--prepare' option. Consider re-running the benchmark on a quiet system. Maybe it was a random outlier. Alternatively, consider increasing the warmup count.

Summary
  python3 -c "import pepotron" ran
    1.61 ± 0.09 times faster than python3 -c "import    pepotron"
```
