### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.10", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["pypy3.10", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [Windows, macOS, Ubuntu]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
 ]
 license = { text = "MIT" }
 authors = [ { name = "Hugo van Kemenade" } ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
@@ -24,7 +24,6 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ env_list =
     cli
     cog
     lint
-    py{py3, 313, 312, 311, 310, 39, 38}
+    py{py3, 313, 312, 311, 310, 39}
 
 [testenv]
 extras =


### PR DESCRIPTION
It will be end-of-life next month:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0569/
* https://endoflife.date/python
