### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.10", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["pypy3.10", "3.14", "3.13", "3.12", "3.11", "3.10", "3.9"]
         os: [Windows, macOS, Ubuntu]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.10", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["pypy3.10", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [Windows, macOS, Ubuntu]
 
     steps:
@@ -38,7 +38,7 @@ jobs:
           uvx --with tox-uv tox -e cli
 
       - name: Cog
-        if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
+        if: matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest'
         run: |
           uvx --with tox-uv tox -e cog
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -92,7 +93,7 @@ lint.isort.known-first-party = [ "pepotron" ]
 lint.isort.required-imports = [ "from __future__ import annotations" ]
 
 [tool.pyproject-fmt]
-max_supported_python = "3.13"
+max_supported_python = "3.14"
 
 [tool.pytest.ini_options]
 addopts = "--color=yes"

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ env_list =
     cog
     lint
     mypy
-    py{py3, 313, 312, 311, 310, 39}
+    py{py3, 314, 313, 312, 311, 310, 39}
 
 [testenv]
 extras =


### PR DESCRIPTION
* https://devguide.python.org/versions/
* https://peps.python.org/pep-0745/

Also reverse the order of versions so 3.14 is started earlier. It's uncached in the CI, and may need to build some sdists when wheels are not available. Uses same amount of CI time in total, but end-to-end is quicker: 3m26s -> 2m52s.

