### PR TITLE
Enable colour help for Python 3.14

### DIFF
--- a/src/pepotron/cli.py
+++ b/src/pepotron/cli.py
@@ -36,6 +36,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
+    parser.color = True
     parser.add_argument(
         "search",
         nargs="*",

--- a/src/pepotron/cli.py
+++ b/src/pepotron/cli.py
@@ -36,7 +36,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    parser.color = True
+    parser.color = True  # type: ignore[attr-defined]
     parser.add_argument(
         "search",
         nargs="*",


### PR DESCRIPTION
Will be available for 3.14 beta:

https://docs.python.org/3.14/library/argparse.html#color

