### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.10", "3.14", "3.13", "3.12", "3.11", "3.10", "3.9"]
+        python-version: ["pypy3.10", "3.14", "3.13", "3.12", "3.11", "3.10"]
         os: [Windows, macOS, Ubuntu]
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.2
+    rev: v0.13.3
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.1.0
+    rev: 25.9.0
     hooks:
       - id: black
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -25,7 +25,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.33.2
+    rev: 0.34.0
     hooks:
       - id: check-github-workflows
       - id: check-renovate
@@ -36,7 +36,7 @@ repos:
       - id: actionlint
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.6.0
+    rev: v2.7.0
     hooks:
       - id: pyproject-fmt
 
@@ -46,7 +46,7 @@ repos:
       - id: validate-pyproject
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
-    rev: 1.5.0
+    rev: 1.6.0
     hooks:
       - id: tox-ini-fmt
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
 ]
 license = { text = "MIT" }
 authors = [ { name = "Hugo van Kemenade" } ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
@@ -24,7 +24,6 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/src/pepotron/_cache.py
+++ b/src/pepotron/_cache.py
@@ -7,17 +7,13 @@ from __future__ import annotations
 import datetime as dt
 import json
 import logging
-import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from platformdirs import user_cache_dir
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
-    if sys.version_info >= (3, 10):
-        from typing import TypeAlias
-    else:
-        from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 PepData: TypeAlias = "dict[str, dict[str, str]]"
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ env_list =
     cog
     lint
     mypy
-    py{py3, 314, 313, 312, 311, 310, 39}
+    py{py3, 314, 313, 312, 311, 310}
 
 [testenv]
 extras =


### PR DESCRIPTION
It's almost end-of-life:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0596/

Also bump pre-commit.