### PR TITLE
Add spinner for `pep next`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "python-slugify",
   "rapidfuzz",
   "urllib3>=2",
+  "yaspin",
 ]
 optional-dependencies.tests = [
   "freezegun",
@@ -100,6 +101,9 @@ max_supported_python = "3.15"
 [tool.pytest.ini_options]
 addopts = "--color=yes"
 testpaths = [ "tests" ]
+filterwarnings = [
+  "ignore:color, on_color and attrs are not supported when output stream is not a TTY:UserWarning:yaspin",
+]
 
 [tool.coverage.run]
 omit = [

--- a/src/pepotron/__init__.py
+++ b/src/pepotron/__init__.py
@@ -5,6 +5,7 @@ CLI to open PEPs in your browser
 from __future__ import annotations
 
 import logging
+from itertools import pairwise
 from pathlib import Path
 from typing import Any
 
@@ -93,18 +94,6 @@ def _get_published_peps() -> set[int]:
 
 
 def _next_available_pep() -> int:
-    try:
-        # Python 3.10+
-        from itertools import pairwise
-    except ImportError:
-        # Python 3.9 and below
-        def pairwise(iterable):  # type: ignore[no-redef,no-untyped-def]
-            from itertools import tee
-
-            a, b = tee(iterable)
-            next(b, None)
-            return zip(a, b)
-
     published = _get_published_peps()
     proposed = _get_pr_peps()
     combined = published | proposed
@@ -182,7 +171,10 @@ def pep_url(search: str | None, base_url: str = BASE_URL, pr: int | None = None)
         return result + f"/topic/{search}/"
 
     if search.lower() == "next":
-        return f"Next available PEP: {_next_available_pep()}"
+        from yaspin import yaspin
+
+        with yaspin(color="yellow"):
+            return f"Next available PEP: {_next_available_pep()}"
 
     try:
         # pep 8


### PR DESCRIPTION
`pep next` is a bit slow because it has to download the PEPs API JSON (although this might be cached) and also iterate over the open PEPs PRs.