### PR TITLE
`pep next`: skip 812

### DIFF
--- a/src/pepotron/__init__.py
+++ b/src/pepotron/__init__.py
@@ -88,7 +88,7 @@ def _next_available_pep() -> int:
     combined = published | proposed
     numbers = sorted(combined)
 
-    start = 715
+    start = 828
     next_pep = -1
     for x, y in pairwise(numbers):
         if x < start:


### PR DESCRIPTION
PEP 812 was assigned to a PR which was closed without merge.

Let's skip it.

Re: 

* https://github.com/python/peps/pull/4681
* https://github.com/python/peps/pull/4854#discussion_r2904391826