### PR TITLE
Replace flaky httpbin.org call with mock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ lint.select = [
   "PYI",    # flake8-pyi
   "RUF022", # unsorted-dunder-all
   "RUF100", # unused noqa (yesqa)
+  "SIM117", # multiple-with-statements
   "UP",     # pyupgrade
   "W",      # pycodestyle warnings
   "YTT",    # flake8-2020

--- a/tests/test_pepotron.py
+++ b/tests/test_pepotron.py
@@ -5,8 +5,10 @@ Unit tests
 from __future__ import annotations
 
 from typing import NamedTuple
+from unittest import mock
 
 import pytest
+import urllib3
 
 import pepotron
 
@@ -110,8 +112,12 @@ def test__get_peps_ok() -> None:
 
 
 def test__get_peps_error() -> None:
-    with pytest.raises(RuntimeError):
-        pepotron._get_peps("https://httpbin.org/status/404")
+    response = mock.Mock(status=404)
+    with (
+        mock.patch.object(urllib3, "request", return_value=response),
+        pytest.raises(RuntimeError, match="status 404"),
+    ):
+        pepotron._get_peps("https://example.com/peps.json")
 
 
 def test_pep() -> None:

--- a/tests/test_pepotron.py
+++ b/tests/test_pepotron.py
@@ -34,7 +34,7 @@ def test_url(search: str, expected_url: str) -> None:
     assert pep_url == expected_url
 
 
-def test_next(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_next() -> None:
     # Arrange
     class Pull(NamedTuple):
         title: str
@@ -43,10 +43,10 @@ def test_next(monkeypatch: pytest.MonkeyPatch) -> None:
         Pull(title="PEP 716: Seven One Six"),
         Pull(title="PEP 717: Seven One Seven"),
     ]
-    monkeypatch.setattr(pepotron, "_get_github_prs", lambda: prs)
 
     # Act
-    next_pep = pepotron.pep_url("next")
+    with mock.patch.object(pepotron, "_get_github_prs", return_value=prs):
+        next_pep = pepotron.pep_url("next")
 
     # Assert
     assert next_pep.startswith("Next available PEP: ")


### PR DESCRIPTION
httpbin.prg occasionally fails like:

```pytb
self = <urllib3.connectionpool.HTTPSConnectionPool object at 0x0000020a072832b8>
err = TimeoutError('The read operation timed out'), url = '/status/404'
timeout_value = 3

    def _raise_timeout(
        self,
        err: BaseSSLError | OSError | SocketTimeout,
        url: str,
        timeout_value: _TYPE_TIMEOUT | None,
    ) -> None:
        """Is the error actually a timeout? Will raise a ReadTimeout or pass"""
    
        if isinstance(err, SocketTimeout):
>           raise ReadTimeoutError(
                self, url, f"Read timed out. (read timeout={timeout_value})"
            ) from err
E           urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='httpbin.org', port=443): Read timed out. (read timeout=3)

.tox\py\Lib\site-packages\urllib3\connectionpool.py:367: ReadTimeoutError

The above exception was the direct cause of the following exception:

    def test__get_peps_error() -> None:
        with pytest.raises(RuntimeError):
>           pepotron._get_peps("https://httpbin.org/status/404")
                     ^^^^^^^^^
```

https://github.com/hugovk/pepotron/actions/runs/28603904002/job/84818996967?pr=105 in https://github.com/hugovk/pepotron/pull/105.

Let's replace with a mock so we don't need to make any network calls.

Also replace a `monkeytest` with `unittest.mock`.