### PR TITLE
Pin ghapi<2 to fix TypeError: 'coroutine' object is not iterable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 dynamic = [ "version" ]
 dependencies = [
-  "ghapi",
+  "ghapi<2",
   "platformdirs",
   "python-slugify",
   "rapidfuzz",


### PR DESCRIPTION
Fix https://github.com/hugovk/pepotron/issues/109.

Breaking change in ghapi 2.0:

* By default, GhApi is now async. All helper methods are async
  * `GhApi(sync=True)` gives you the v1-style sync interface, although helpers don't work with sync

https://github.com/AnswerDotAI/ghapi/releases/tag/2.0.0

The quick fix whilst I'm at EuroPython is pinning ghapi<2. Maybe we'll do `GhApi(sync=True)` later, or drop/replace the GhApi dependency.