### PR TITLE
Replace ghapi dependency with urllib3 call

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ classifiers = [
 ]
 dynamic = [ "version" ]
 dependencies = [
-  "ghapi<2",
   "platformdirs",
   "python-slugify",
   "rapidfuzz",

--- a/src/pepotron/__init__.py
+++ b/src/pepotron/__init__.py
@@ -101,10 +101,24 @@ def _next_available_pep() -> int:
 
 
 def _get_github_prs() -> list[Any]:
-    from ghapi.all import GhApi
+    import urllib3
 
-    api = GhApi(owner="python", repo="peps", authenticate=False)
-    return api.pulls.list(per_page=100)
+    prs_url = "https://api.github.com/repos/python/peps/pulls?per_page=100"
+    resp = urllib3.request(
+        "GET",
+        prs_url,
+        headers={
+            "User-Agent": USER_AGENT,
+            "Accept": "application/vnd.github+json",
+        },
+    )
+
+    logger.info("HTTP status code: %s", resp.status)
+    if resp.status != 200:
+        msg = f"Unable to download {prs_url}: status {resp.status}"
+        raise RuntimeError(msg)
+
+    return resp.json()
 
 
 def _get_pr_peps() -> set[int]:
@@ -114,7 +128,7 @@ def _get_pr_peps() -> set[int]:
 
     numbers = set()
     for pr in _get_github_prs():
-        if match := re.search(pr_title_regex, pr.title):
+        if match := re.search(pr_title_regex, pr["title"]):
             number = match[1]
             numbers.add(int(number))
 

--- a/tests/test_pepotron.py
+++ b/tests/test_pepotron.py
@@ -4,7 +4,6 @@ Unit tests
 
 from __future__ import annotations
 
-from typing import NamedTuple
 from unittest import mock
 
 import pytest
@@ -36,12 +35,9 @@ def test_url(search: str, expected_url: str) -> None:
 
 def test_next() -> None:
     # Arrange
-    class Pull(NamedTuple):
-        title: str
-
     prs = [
-        Pull(title="PEP 716: Seven One Six"),
-        Pull(title="PEP 717: Seven One Seven"),
+        {"title": "PEP 716: Seven One Six"},
+        {"title": "PEP 717: Seven One Seven"},
     ]
 
     # Act


### PR DESCRIPTION
Follow on from https://github.com/hugovk/pepotron/pull/110 and https://github.com/hugovk/pepotron/pull/112.

ghapi v2 is now async by default. https://github.com/hugovk/pepotron/pull/110 was a quick fix to pin `ghapi<2`.

Rather than upgrading to v2, or setting `sync=True`, we're only making one unauthenticated GitHub call, so we can do that directly via urllib3 without a GitHub library.